### PR TITLE
fix location of x265 easyconfig + minor style fixes

### DIFF
--- a/easybuild/easyconfigs/x/x265/x265-1.9-goolf-1.7.20.eb
+++ b/easybuild/easyconfigs/x/x265/x265-1.9-goolf-1.7.20.eb
@@ -9,12 +9,13 @@ description = """x265 is a free software library and application for encoding vi
 
 toolchain = {'name': 'goolf', 'version': '1.7.20'}
 
-
 source_urls = ['http://ftp.videolan.org/pub/videolan/x265/']
 sources = ['x265_%(version)s.tar.gz']
 
-dependencies = [('CMake', '2.8.11'),
-                ('Yasm','1.3.0'),]
+builddependencies = [('CMake', '2.8.11')]
+dependencies = [
+    ('Yasm','1.3.0'),
+]
 
 start_dir = 'source'
 


### PR DESCRIPTION
@eediaz1987 this fixes the issue with the location of the easyconfig file in https://github.com/hpcugent/easybuild-easyconfigs/pull/3090

You'll still need to reopen that PR to target the `develop` branch though...
